### PR TITLE
Added a MUXF8 module as an exact duplicate of the of MUXF* modules.

### DIFF
--- a/MUXF8.v
+++ b/MUXF8.v
@@ -1,0 +1,16 @@
+`timescale  1 ps / 1 ps
+
+module MUXF8 (O, I0, I1, S);
+
+    output O;
+    reg    O;
+
+    input  I0, I1, S;
+
+	always @(I0 or I1 or S) 
+	    if (S)
+		O = I1;
+	    else
+		O = I0;
+endmodule
+


### PR DESCRIPTION
Pretty self-explanatory. Added an extra module for the MUXF8. It appears to work exactly the same as the other MUXF* modules. I'm using your library to test post-synthesis structural verilog produced by Vivado using PyVerilator. Vivado occasionally used this resource on an Alveo U280 and so the generated post-synthesis verilog tries to instantiate it. It works in my tests (https://github.com/Xilinx/logicnets).

Thanks for making this great library!